### PR TITLE
fix: handle Linkerd injection annotation correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Chart padrão para aplicações helm chart
 helm package kubernetes-java-helm
 
 # 3) Enviar
-helm push ./kubernetes-java-helm-1.0.1.tgz oci://ghcr.io/lucasbertidev/charts
+helm push ./kubernetes-java-helm-1.0.5.tgz oci://ghcr.io/lucasbertidev/charts

--- a/kubernetes-java-helm/Chart.yaml
+++ b/kubernetes-java-helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kubernetes-java-helm
 description: Chart genérico para aplicações Kubernetes Java Helm
 type: application
-version: 1.0.4
+version: 1.0.5
 appVersion: "1.0.0"

--- a/kubernetes-java-helm/templates/deployment.yaml
+++ b/kubernetes-java-helm/templates/deployment.yaml
@@ -13,11 +13,13 @@ spec:
       {{- include "app.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- if or .Values.podAnnotations .Values.linkerd.enabled }}
       annotations:
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-        {{- if .Values.linkerd.enabled}}
-        linkerd.io/inject: enabled        
+        {{- end }}
+        {{- if .Values.linkerd.enabled }}
+        linkerd.io/inject: enabled
         {{- end }}
       {{- end }}
       labels:


### PR DESCRIPTION
## Summary
- ensure Linkerd injection annotation is added even when no other pod annotations are provided
- bump chart version to 1.0.5
- update README to reference new chart package version

## Testing
- `helm version --short` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae727b679883238cd6485b78dc4e8d