### PR TITLE
fix: replace opa helper references in HPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,8 @@ Chart padrão para aplicações helm chart
 # 1) Empacotar o chart
 helm package kubernetes-java-helm
 
+# 2) Verificar o chart
+helm template test-release kubernetes-java-helm
+
 # 3) Enviar
 helm push ./kubernetes-java-helm-1.0.1.tgz oci://ghcr.io/lucasbertidev/charts

--- a/kubernetes-java-helm/templates/hpa.yaml
+++ b/kubernetes-java-helm/templates/hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "opa.fullname" . }}
+  name: {{ include "app.fullname" . }}
   labels:
-    {{- include "opa.labels" . | nindent 4 }}
+    {{- include "app.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "opa.fullname" . }}
+    name: {{ include "app.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:


### PR DESCRIPTION
## Summary
- use `app.fullname` and `app.labels` helpers in `hpa.yaml`
- document chart verification with `helm template`

## Testing
- `helm template test-release kubernetes-java-helm` *(fails: command not found: helm)*


------
https://chatgpt.com/codex/tasks/task_e_68ae73cffd208323a53d01cf772d5be3