### PR TITLE
test: add timeout and spider to connection test

### DIFF
--- a/kubernetes-java-helm/templates/tests/test-connection.yaml
+++ b/kubernetes-java-helm/templates/tests/test-connection.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "app.fullname" . }}-test-connection"
+  name: "{{ include \"app.fullname\" . }}-test-connection"
   labels:
     {{- include "app.labels" . | nindent 4 }}
   annotations:
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: [ '{{ include "app.fullname" . }}:{{ .Values.service.port }}/actuator/health' ]
+      args: ['--spider', '--timeout=5', '--tries=1', '{{ include "app.fullname" . }}:{{ .Values.service.port }}/actuator/health' ]
   restartPolicy: Never


### PR DESCRIPTION
## Summary
- expand Helm test connection to use wget with spider mode and timeout

## Testing
- `helm template test-release kubernetes-java-helm` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ae75821a14832394b65857d40c59f4