### PR TITLE
Add JSON schema validation for Helm chart

### DIFF
--- a/kubernetes-java-helm/Chart.yaml
+++ b/kubernetes-java-helm/Chart.yaml
@@ -4,3 +4,4 @@ description: Chart genérico para aplicações Kubernetes Java Helm
 type: application
 version: 1.0.5
 appVersion: "1.0.0"
+schema: values.schema.json

--- a/kubernetes-java-helm/values.schema.json
+++ b/kubernetes-java-helm/values.schema.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "serviceMonitor": {
+      "type": "object",
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "metricsPortName": {"type": "string"},
+        "metricsPath": {"type": "string"},
+        "scrapingInterval": {"type": "string"},
+        "metricRelabelings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "action": {"type": "string"},
+              "sourceLabels": {"type": "array", "items": {"type": "string"}},
+              "regex": {"type": "string"},
+              "targetLabel": {"type": "string"},
+              "replacement": {"type": "string"}
+            },
+            "required": ["action", "sourceLabels", "regex", "targetLabel", "replacement"]
+          }
+        }
+      },
+      "required": ["enabled", "metricsPortName", "metricsPath", "scrapingInterval"]
+    },
+    "replicaCount": {"type": "integer", "minimum": 1},
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {"type": "string"},
+        "pullPolicy": {"type": "string"},
+        "tag": {"type": "string"}
+      },
+      "required": ["repository", "pullPolicy", "tag"]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {"type": "object"}
+    },
+    "nameOverride": {"type": "string"},
+    "fullnameOverride": {"type": "string"},
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {"type": "boolean"},
+        "annotations": {"type": "object"},
+        "name": {"type": "string"}
+      },
+      "required": ["create"]
+    },
+    "linkerd": {
+      "type": "object",
+      "properties": {
+        "enabled": {"type": "boolean"}
+      },
+      "required": ["enabled"]
+    },
+    "podAnnotations": {"type": "object"},
+    "podSecurityContext": {"type": "object"},
+    "securityContext": {"type": "object"},
+    "service": {
+      "type": "object",
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "type": {"type": "string"},
+        "port": {"type": "integer"}
+      },
+      "required": ["enabled", "type", "port"]
+    },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": {"type": ["string", "number"]},
+            "memory": {"type": "string"}
+          },
+          "required": ["cpu", "memory"]
+        },
+        "limits": {
+          "type": "object",
+          "properties": {
+            "cpu": {"type": ["string", "number"]},
+            "memory": {"type": "string"}
+          },
+          "required": ["cpu", "memory"]
+        }
+      },
+      "required": ["requests", "limits"]
+    },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "minReplicas": {"type": "integer"},
+        "maxReplicas": {"type": "integer"},
+        "targetCPUUtilizationPercentage": {"type": "integer"}
+      },
+      "required": ["enabled", "minReplicas", "maxReplicas", "targetCPUUtilizationPercentage"]
+    },
+    "nodeSelector": {"type": "object"},
+    "tolerations": {"type": "array", "items": {"type": "object"}},
+    "affinity": {"type": "object"},
+    "envFrom": {"type": "object"},
+    "env": {"type": "object"},
+    "livenessProbe": {
+      "type": "object",
+      "properties": {
+        "initialDelaySeconds": {"type": "integer"},
+        "httpGet": {
+          "type": "object",
+          "properties": {
+            "path": {"type": "string"},
+            "port": {"type": ["string", "integer"]}
+          },
+          "required": ["path", "port"]
+        }
+      },
+      "required": ["initialDelaySeconds", "httpGet"]
+    },
+    "readinessProbe": {
+      "type": "object",
+      "properties": {
+        "initialDelaySeconds": {"type": "integer"},
+        "httpGet": {
+          "type": "object",
+          "properties": {
+            "path": {"type": "string"},
+            "port": {"type": ["string", "integer"]}
+          },
+          "required": ["path", "port"]
+        }
+      },
+      "required": ["initialDelaySeconds", "httpGet"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add values.schema.json to validate Helm values
- reference schema in Chart.yaml

## Testing
- `helm lint kubernetes-java-helm` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae762f864c8323b22d261a7f75dbd9